### PR TITLE
test: add a test confirming terminable route middleware is called

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http;
 
+use App\Http\Middleware\ApiAfter;
 use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
@@ -50,6 +51,7 @@ final class Kernel extends HttpKernel
         'api' => [
             'throttle:api',
             SubstituteBindings::class,
+            ApiAfter::class,
         ],
     ];
 

--- a/app/Http/Middleware/ApiAfter.php
+++ b/app/Http/Middleware/ApiAfter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Jobs\SampleJob;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ApiAfter
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        return $next($request);
+    }
+
+    public function terminate(Request $request, Response $response): void
+    {
+        dispatch(new SampleJob());
+    }
+}

--- a/app/Jobs/SampleJob.php
+++ b/app/Jobs/SampleJob.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SampleJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function handle()
+    {
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,4 +12,5 @@ Route::middleware('auth:api')->get('/user',
     fn(Request $request) => $request->user()
 );
 
+Route::get('/ping', fn(Request $request) => 'pong');
 Route::post('/upload-files', [TestController::class, 'uploadFiles']);

--- a/tests/Functional/MiddlewaresCest.php
+++ b/tests/Functional/MiddlewaresCest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Functional;
+
+use App\Jobs\SampleJob;
+use Illuminate\Support\Facades\Queue;
+use Tests\FunctionalTester;
+
+class MiddlewaresCest
+{
+    public function terminableRouteMiddlewareIsCalled(FunctionalTester $I): void
+    {
+        Queue::fake();
+
+        $I->amOnPage('/api/ping');
+
+        Queue::assertPushed(SampleJob::class);
+    }
+}


### PR DESCRIPTION
Related to: https://github.com/Codeception/module-laravel/pull/52

I wasn't sure how to make the assert so I went for checking a Job is dispatched to asses if the method is called. If you can think of something simpler and/or better naming let me know please. 